### PR TITLE
remove resourcename restriction for secrets

### DIFF
--- a/deploy/helm-chart/kube-mail/templates/rbac.yaml
+++ b/deploy/helm-chart/kube-mail/templates/rbac.yaml
@@ -17,7 +17,6 @@ rules:
   - watch
 - apiGroups: [""]
   resources: ["secrets"]
-  resourceNames: ["smtp-credentials"]
   verbs:
   - get
   - list


### PR DESCRIPTION
This cannot work with a CR that accepts any secret name as smtp credentials