### PR TITLE
helm-chart: add support for manually deployed/extrnal redis server

### DIFF
--- a/deploy/helm-chart/kube-mail/Chart.yaml
+++ b/deploy/helm-chart/kube-mail/Chart.yaml
@@ -6,3 +6,4 @@ dependencies:
   - name: redis
     version: 11.2.1
     repository: https://charts.bitnami.com/bitnami
+    condition: redis.enabled

--- a/deploy/helm-chart/kube-mail/templates/_helpers.tpl
+++ b/deploy/helm-chart/kube-mail/templates/_helpers.tpl
@@ -47,3 +47,17 @@ Selector labels
 app.kubernetes.io/name: {{ include "chart.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+{{/*
+Return the Redis hostname
+*/}}
+{{- define "chart.redis.host" -}}
+{{- ternary (printf "%s-redis" (include "chart.fullname" .)) .Values.externalRedis.host .Values.redis.enabled -}}
+{{- end -}}
+
+{{/*
+Return the Redis port
+*/}}
+{{- define "chart.redis.port" -}}
+{{- ternary .Values.redis.redisPort .Values.externalRedis.port .Values.redis.enabled -}}
+{{- end -}}

--- a/deploy/helm-chart/kube-mail/templates/deployment.yaml
+++ b/deploy/helm-chart/kube-mail/templates/deployment.yaml
@@ -67,9 +67,9 @@ spec:
               value: {{ .Values.redis.sentinel.masterSet | quote }}
             {{- else }}
             - name: KUBEMAIL_REDIS_HOST
-              value: redis://{{ template "chart.fullname" . }}-redis
+              value: {{ include "chart.redis.host" . }}
             - name: KUBEMAIL_REDIS_PORT
-              value: {{ .Values.redis.redisPort | quote }}
+              value: {{ include "chart.redis.port" . | quote }}
             {{- end }}
             - name: DEBUG
               value: "*"

--- a/deploy/helm-chart/kube-mail/values.yaml
+++ b/deploy/helm-chart/kube-mail/values.yaml
@@ -64,9 +64,13 @@ resources: {}
   #  cpu: 100m
   #  memory: 128Mi
 redis:
+  enabled: true
   sentinel:
     enabled: true
   usePassword: false
   networkPolicy:
     enabled: true
     allowExternal: false
+externalRedis:
+  # port:
+  # host:


### PR DESCRIPTION
this change allows redis to remain unmanaged by this chart and instead relies on the user deploying their own redis server. connection information can be passed via new chart values.