### PR TITLE
helm-chart: add support for security context settings

### DIFF
--- a/deploy/helm-chart/kube-mail/templates/deployment.yaml
+++ b/deploy/helm-chart/kube-mail/templates/deployment.yaml
@@ -31,10 +31,16 @@ spec:
       {{- if .Values.rbac.enabled }}
       serviceAccountName: {{ template "chart.fullname" . }}
       {{- end }}
+      {{- if .Values.podSecurityContext.enabled }}
+      securityContext: {{- omit .Values.podSecurityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.containerSecurityContext.enabled }}
+          securityContext: {{- omit .Values.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
           ports:
             - containerPort: {{ .Values.smtp.service.internalPort }}
               name: smtp

--- a/deploy/helm-chart/kube-mail/values.yaml
+++ b/deploy/helm-chart/kube-mail/values.yaml
@@ -8,6 +8,13 @@ image:
   pullPolicy: Always
 rbac:
   enabled: true
+podSecurityContext:
+  enabled: false
+  fsGroup: 1001
+containerSecurityContext:
+  enabled: false
+  runAsUser: 1001
+  runAsNonRoot: true
 smtp:
   service:
     externalPort: 25


### PR DESCRIPTION
the container listens on unprivileged ports, so tighter restrictions can be applied. to remain backwards compatible, the new settings are disabled by default.