### PR TITLE
helm-chart: add support for volume mounts

### DIFF
--- a/deploy/helm-chart/kube-mail/templates/deployment.yaml
+++ b/deploy/helm-chart/kube-mail/templates/deployment.yaml
@@ -85,7 +85,13 @@ spec:
             {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
+          {{- if .Values.extraVolumeMounts }}
+          volumeMounts: {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
+          {{- end }}
     {{- if .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
     {{- end }}
+      {{- if .Values.extraVolumes }}
+      volumes: {{ toYaml .Values.extraVolumes | nindent 8 }}
+      {{- end }}

--- a/deploy/helm-chart/kube-mail/values.yaml
+++ b/deploy/helm-chart/kube-mail/values.yaml
@@ -52,6 +52,8 @@ prometheus:
   #   - namespaceSelector:
   #       matchLabels:
   #         kubernetes.io/metadata.name: monitoring
+extraVolumeMounts: []
+extraVolumes: []
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
this change allows users to mount custom volumes into the container. the main intention is to provide certificate stores to nodejs when using TLS with custom certs/CAs.