### PR TITLE
Add Enum to specify connect method

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,7 @@ jobs:
         with:
           go-version: '^1.18'
       - name: install controller-gen
-        run: go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.9.0
+        run: go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.11.3
       - run: npm ci
       - run: make generate
       - name: assert no files are modified

--- a/deploy/helm-chart/kube-mail/crds/kube-mail.helmich.me_emailpolicies.yaml
+++ b/deploy/helm-chart/kube-mail/crds/kube-mail.helmich.me_emailpolicies.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.0
+    controller-gen.kubebuilder.io/version: v0.11.3
   creationTimestamp: null
   name: emailpolicies.kube-mail.helmich.me
 spec:
@@ -94,6 +94,7 @@ spec:
                       are ANDed.
                     type: object
                 type: object
+                x-kubernetes-map-type: atomic
               ratelimiting:
                 properties:
                   maximum:

--- a/deploy/helm-chart/kube-mail/crds/kube-mail.helmich.me_smtpservers.yaml
+++ b/deploy/helm-chart/kube-mail/crds/kube-mail.helmich.me_smtpservers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.0
+    controller-gen.kubebuilder.io/version: v0.11.3
   creationTimestamp: null
   name: smtpservers.kube-mail.helmich.me
 spec:
@@ -48,11 +48,18 @@ spec:
                 - CRAM-MD5
                 - SCRAM-SHA-1
                 type: string
+              connect:
+                enum:
+                - plain
+                - ssl
+                - starttls
+                type: string
               port:
                 type: integer
               server:
                 type: string
               tls:
+                description: 'DEPRECATED: Use Connect, instead'
                 type: boolean
             required:
             - server

--- a/go/apis/kube-mail/v1alpha1/smtpserver_types.go
+++ b/go/apis/kube-mail/v1alpha1/smtpserver_types.go
@@ -25,9 +25,9 @@ type SMTPServerSpec struct {
 	// +optional
 	Port int `json:"port,omitempty"`
 
-  // DEPRECATED: Use Connect, instead
-  // +kubebuilder:deprecatedversion:warning="TLS is deprecated use Connect instead."
-  // +optional
+	// DEPRECATED: Use Connect, instead
+	// +kubebuilder:deprecatedversion:warning="TLS is deprecated use Connect instead."
+	// +optional
 	TLS bool `json:"tls,omitempty"`
 	
 	// +kubebuilder:validation:Enum=plain;ssl;starttls

--- a/go/apis/kube-mail/v1alpha1/smtpserver_types.go
+++ b/go/apis/kube-mail/v1alpha1/smtpserver_types.go
@@ -11,14 +11,28 @@ const (
 	SMTPAuthTypeSCRAMSHA1 SMTPAuthType = "SCRAM-SHA-1"
 )
 
+type SMTPConnectType string
+
+const (
+	SMTPConnectTypePlain     SMTPConnectType = "plain"
+	SMTPConnectTypeSSL     SMTPConnectType = "ssl"
+	SMTPConnectTypeSTARTTLS SMTPConnectType = "starttls"
+)
+
 type SMTPServerSpec struct {
 	Server string `json:"server"`
 
 	// +optional
 	Port int `json:"port,omitempty"`
 
-	// +optional
+  // DEPRECATED: Use Connect, instead
+  // +kubebuilder:deprecatedversion:warning="TLS is deprecated use Connect instead."
+  // +optional
 	TLS bool `json:"tls,omitempty"`
+	
+	// +kubebuilder:validation:Enum=plain;ssl;starttls
+	// +optional
+	Connect SMTPConnectType `json:"connect,omitempty" ts_type:"connect"`
 
 	// +optional
 	// +kubebuilder:validation:Enum=PLAIN;LOGIN;CRAM-MD5;SCRAM-SHA-1

--- a/go/generate/types.go
+++ b/go/generate/types.go
@@ -34,7 +34,7 @@ func main() {
 	t.CreateInterface = true
 	t.BackupDir = ""
 
-	t.AddImport(`import {authType} from "./enums"`)
+	t.AddImport(`import {authType, connect} from "./enums"`)
 
 	t.Add(v1alpha1.SMTPServerSpec{})
 

--- a/src/k8s/types/v1alpha1/enums.ts
+++ b/src/k8s/types/v1alpha1/enums.ts
@@ -1,2 +1,3 @@
 export type authType = "PLAIN" | "LOGIN" | "CRAM-MD5" | "SCRAM-SHA-1";
 export type policyPeriod = "hour" | "minute";
+export type connect = "plain" | "ssl" | "starttls";

--- a/src/k8s/types/v1alpha1/smtpserver_spec.ts
+++ b/src/k8s/types/v1alpha1/smtpserver_spec.ts
@@ -1,10 +1,11 @@
 /* Do not change, this code is generated from Golang structs */
 
-import {authType} from "./enums"
+import {authType, connect} from "./enums"
 
 export interface SMTPServerSpec {
     server: string;
     port?: number;
     tls?: boolean;
+    connect?: connect;
     authType?: authType;
 }

--- a/src/policy/kubernetes.ts
+++ b/src/policy/kubernetes.ts
@@ -84,6 +84,15 @@ export class KubernetesPolicyProvider implements PolicyProvider {
             if (!smtpServer) {
                 return [undefined, pod];
             }
+           
+            let connect: "plain" | "ssl" | "starttls";
+            // Convert deprecated tls field to connect
+            if (smtpServer.spec.connect === undefined) {
+              let tls = smtpServer.spec.tls === undefined ? true : smtpServer.spec.tls;
+              connect = tls ? "ssl" : "plain";
+            } else {
+              connect = smtpServer.spec.connect;
+            }
 
             const forwardPolicy: ForwardPolicy = {
                 id: objectMetaToString(policy),
@@ -96,7 +105,7 @@ export class KubernetesPolicyProvider implements PolicyProvider {
                     name: smtpServer.metadata.name,
                     server: smtpServer.spec.server,
                     port: smtpServer.spec.port || 587,
-                    tls: smtpServer.spec.tls === undefined ? true : smtpServer.spec.tls,
+                    connect: connect,
                 },
             };
 

--- a/src/policy/provider.ts
+++ b/src/policy/provider.ts
@@ -23,7 +23,7 @@ export type ForwardPolicy = {
         namespace: string;
         server: string;
         port: number;
-        tls?: boolean;
+        connect?: "plain" | "ssl" | "starttls";
         auth?: {
             method: "PLAIN" | "LOGIN" | "CRAM-MD5" | "SCRAM-SHA-1";
             username: string;

--- a/src/upstream/smtp.ts
+++ b/src/upstream/smtp.ts
@@ -55,7 +55,7 @@ export class SMTPUpstream {
     }
 
     private connectionForPolicy(policy: ForwardPolicy): Promise<PromisifiedSMTPConnection> {
-        const {server, port, tls, auth} = policy.smtp;
+        const {server, port, connect, auth} = policy.smtp;
         const enableDebug = policy.smtp.debug === undefined ? false : policy.smtp.debug;
         const enableLogger = policy.smtp.logger === undefined ? false : policy.smtp.logger;
         const {name, connectionTimeout, socketTimeout} = this.options;
@@ -65,8 +65,9 @@ export class SMTPUpstream {
         const conn = new SMTPConnection({
             host: server,
             port: port,
-            secure: tls,
-            ignoreTLS: !tls,
+            secure: connect === "ssl",
+            ignoreTLS: connect === "plain",
+            requireTLS: connect === "starttls",
             name,
             connectionTimeout,
             socketTimeout,


### PR DESCRIPTION
Fixes https://github.com/mittwald/kube-mail/issues/65

Hey! This PR is a first step to be able to add STARTTLS support as the current implementation only supports SSL and not TLS due to the `secure` parameter being set to `true` on `TLS: true`.

As this is the first time I'm writing typescript please let me know how I could accomplish this in a better way :).

I also did not account for any deprecation of the TLS parameter. If this is something we want, I might need help on how to implement this.