### PR TITLE
Improve Pod read-model by also watching Pending pods

### DIFF
--- a/src/k8s/pod_store.ts
+++ b/src/k8s/pod_store.ts
@@ -33,6 +33,7 @@ export type PodPredicate = (pod: PodWithStatus) => boolean
 export const PodPredicates = {
     Any: (p: PodWithStatus) => true,
     OnlyRunning: (p: PodWithStatus) => p.status.phase === "Running",
+    OnlyRunningOrPending: (p: PodWithStatus) => ["Running", "Pending"].includes(p.status.phase),
 }
 
 export class PodStore implements Store<PodWithStatus> {

--- a/src/policy/factory.ts
+++ b/src/policy/factory.ts
@@ -86,7 +86,7 @@ export class KubernetesPolicyProviderFactory {
             podInformerOptions.labelSelector = podInformerLabelSelectorConfig.selector;
         }
 
-        const podStore = new PodStore(new CachingLookupStore(coreAPIv1.pods()), coreAPIv1.pods(), PodPredicates.OnlyRunning);
+        const podStore = new PodStore(new CachingLookupStore(coreAPIv1.pods()), coreAPIv1.pods(), PodPredicates.OnlyRunningOrPending);
         return [new Informer(coreAPIv1.pods(), podInformerOptions, podStore), podStore];
     }
 

--- a/src/policy/kubernetes.ts
+++ b/src/policy/kubernetes.ts
@@ -48,6 +48,8 @@ export class KubernetesPolicyProvider implements PolicyProvider {
             }
         }
 
+        debug("pod found: %o; labels: %O", pod.metadata.name, pod.metadata.labels);
+
         const {namespace = "", labels = {}} = pod.metadata;
         const policies = this.policyStore.match(namespace, labels);
 


### PR DESCRIPTION
This PR improves the in-memory handling of observed Pods; previously, all observed Pods were discarded unless they were in the "Running" phase -- however, this is racy when a freshly-started Pod immediately starts sending emails 
and the Pod watcher lags behind.
