### PR TITLE
Fix of the chart.redis.port definition

### DIFF
--- a/deploy/helm-chart/kube-mail/templates/_helpers.tpl
+++ b/deploy/helm-chart/kube-mail/templates/_helpers.tpl
@@ -85,5 +85,9 @@ Return the Redis hostname
 Return the Redis port
 */}}
 {{- define "chart.redis.port" -}}
-{{- ternary .Values.redis.master.service.ports.redis .Values.externalRedis.port .Values.redis.enabled -}}
-{{- end -}}
+{{- if .Values.redis.enabled }}
+  {{- .Values.redis.master.service.ports.redis }}
+{{- else }}
+  {{- .Values.externalRedis.port }}
+{{- end }}
+{{- end }}


### PR DESCRIPTION
The function responsible for returning the `chart.redis.port` encounters an issue with its definition. When attempting to specify the port in the values, as demonstrated below:
```
externalRedis:
  host: kube-mail-redis
  port: "5555"
```
an error is encountered:
```
Error: template: kube-mail/templates/deployment.yaml:78:24: executing "kube-mail/templates/deployment.yaml" at <include "chart.redis.port" .>: error calling include: template: kube-mail/templates/_helpers.tpl:88:19: executing "chart.redis.port" at <.Values.redis.master.service.ports.redis>: nil pointer evaluating interface {}.service
```
This error arises because the ternary function expects both values to be defined, and then it selects one based on the test condition. However, `.Values.redis.master.service.ports.redis` is passed from the subchart only if `.Values.redis.enabled` is true, which is not the case here.